### PR TITLE
Add more context to error message from first run of docker client method

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/client"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/bfirsh/whalebrew/packages"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/bfirsh/whalebrew/packages"
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var customPackageName string
@@ -50,7 +51,7 @@ var installCommand = &cobra.Command{
 					return err
 				}
 			} else {
-				return err
+				return fmt.Errorf("failed to inspect docker image: %v", err)
 			}
 		}
 		if imageInspect.ContainerConfig.Entrypoint == nil {


### PR DESCRIPTION
Hi! Thank you for the interesting project! Looks nice.

whalebrew says the following error if docker's client and server version
is different for some reason.

> Error response from daemon: client is newer than server (client API version: 1.26, server API version: 1.24)

But, users cannot get what is 'client', so this commit added more
context to the error message.

I got the message from binary release, but I cannot reproduce it with `go build`... but the error comes from docker cli.get https://github.com/docker/docker/blob/2a3205d7b770fec0eb1f8d90c5342f98a12a74a1/client/request.go#L171