### PR TITLE
Port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ There are some labels you can use to configure how Whalebrew installs your image
 
         LABEL io.whalebrew.config.volumes '["~/.docker:/root/.docker:ro"]'
 
+* `io.whalebrew.config.ports`: A list of host port to container port mappings to create when the command is run. For example, putting this in your images `Dockerfile` will map container port 8100 to host port 8100:
+
+        LABEL io.whalebrew.config.volumes '["8100:8100"]'
+
 ### Whalebrew images
 
 We maintain a set of packages which are known to follow these requirements under the `whalebrew` organization on [GitHub](https://github.com/whalebrew) and [Docker Hub](https://hub.docker.com/u/whalebrew/). If you want to add a package to this, open a pull request against [whalebrew-packages](https://github.com/whalebrew/whalebrew-packages).

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -65,6 +65,10 @@ var runCommand = &cobra.Command{
 			dockerArgs = append(dockerArgs, "-e")
 			dockerArgs = append(dockerArgs, envvar)
 		}
+		for _, portmap := range pkg.Ports {
+			dockerArgs = append(dockerArgs, "-p")
+			dockerArgs = append(dockerArgs, portmap)
+		}
 		dockerArgs = append(dockerArgs, pkg.Image)
 		dockerArgs = append(dockerArgs, args[1:]...)
 

--- a/packages/manager.go
+++ b/packages/manager.go
@@ -25,6 +25,7 @@ type Package struct {
 	Environment []string `yaml:"environment,omitempty"`
 	Image       string   `yaml:"image"`
 	Volumes     []string `yaml:"volumes,omitempty"`
+	Ports       []string `yaml:"ports,omitempty"`
 }
 
 // NewPackageFromImageName creates a package from a given image name,
@@ -57,6 +58,12 @@ func NewPackageFromImageName(image string, imageInspect types.ImageInspect) (*Pa
 
 		if volumesStr, ok := labels["io.whalebrew.config.volumes"]; ok {
 			if err := yaml.Unmarshal([]byte(volumesStr), &pkg.Volumes); err != nil {
+				return pkg, err
+			}
+		}
+
+		if ports, ok := labels["io.whalebrew.config.ports"]; ok {
+			if err := yaml.Unmarshal([]byte(ports), &pkg.Ports); err != nil {
 				return pkg, err
 			}
 		}

--- a/packages/manager_test.go
+++ b/packages/manager_test.go
@@ -62,6 +62,7 @@ func TestPackageManagerInstall(t *testing.T) {
 				"io.whalebrew.name":               "ws",
 				"io.whalebrew.config.environment": "[\"SOME_CONFIG_OPTION\"]",
 				"io.whalebrew.config.volumes":     "[\"/somesource:/somedest\"]",
+				"io.whalebrew.config.ports":       "[\"8100:8100\"]",
 			},
 		},
 	})
@@ -70,6 +71,7 @@ func TestPackageManagerInstall(t *testing.T) {
 	assert.Equal(t, pkg.Image, "whalebrew/whalesay")
 	assert.Equal(t, pkg.Environment, []string{"SOME_CONFIG_OPTION"})
 	assert.Equal(t, pkg.Volumes, []string{"/somesource:/somedest"})
+	assert.Equal(t, pkg.Ports, []string{"8100:8100"})
 
 }
 


### PR DESCRIPTION
This project is awesome! Been working a little on something like it but not in a generalized way so thanks!

I thought it'd be nice to add port mappings. This is a pretty simple version of it but its a start.
Usage would be:
```
LABEL io.whalebrew.config.ports '["8100:8100"]'
```
