### PR TITLE
use executor file permissions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -70,6 +70,14 @@ var runCommand = &cobra.Command{
 			dockerArgs = append(dockerArgs, "-p")
 			dockerArgs = append(dockerArgs, portmap)
 		}
+		
+		user, err := user.Current()
+		if err != nil {
+			return err
+		}
+		dockerArgs = append(dockerArgs, "-u")
+		dockerArgs = append(dockerArgs, user.Uid + ":" + user.Gid)
+		
 		dockerArgs = append(dockerArgs, pkg.Image)
 		dockerArgs = append(dockerArgs, args[1:]...)
 


### PR DESCRIPTION
Set the uid and primary gid as the user executing the command.

For example, if the "ubuntu" user is a member of the docker group, then the permissions one might expect with "whalebrew/wget" might be ubuntu:ubuntu rather than root:root.

```terminal
ubuntu@ip-172-37-43-241:~/$ wget https://www.google.com/favicon.ico
ubuntu@ip-172-37-43-241:~/$ ls -al
-rw-r--r-- 1 ubuntu ubuntu     5430 Dec  8 01:00 favicon.ico
```

Related issues: https://github.com/bfirsh/whalebrew/issues/11, https://github.com/bfirsh/whalebrew/issues/40