### PR TITLE
Fix flag parsing bug in edit command

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -19,7 +19,6 @@ var editCommand = &cobra.Command{
 	Use:                "edit PACKAGENAME",
 	Short:              "Edit a package file",
 	Long:               "Edit a package file using your default editor ($EDITOR).",
-	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return cmd.Help()


### PR DESCRIPTION
$ whalebrew edit -h   
open /usr/local/bin/-h: no such file or directory