### PR TITLE
Added force install support

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,9 +15,11 @@ import (
 )
 
 var customPackageName string
+var forceInstall bool
 
 func init() {
 	installCommand.Flags().StringVarP(&customPackageName, "name", "n", "", "Name to give installed package. Defaults to image name.")
+	installCommand.Flags().BoolVarP(&forceInstall, "force", "f", false, "Replace existing package if already exists. Defaults to false.")
 
 	RootCmd.AddCommand(installCommand)
 }
@@ -67,7 +69,11 @@ var installCommand = &cobra.Command{
 			pkg.Name = customPackageName
 		}
 		pm := packages.NewPackageManager(viper.GetString("install_path"))
-		err = pm.Install(pkg)
+		if forceInstall {
+			err = pm.ForceInstall(pkg)
+		} else {
+			err = pm.Install(pkg)
+		}
 		if err != nil {
 			return err
 		}

--- a/packages/manager.go
+++ b/packages/manager.go
@@ -39,6 +39,19 @@ func (pm *PackageManager) Install(pkg *Package) error {
 	return ioutil.WriteFile(packagePath, d, 0755)
 }
 
+// ForceInstall installs a package
+func (pm *PackageManager) ForceInstall(pkg *Package) error {
+	d, err := yaml.Marshal(&pkg)
+	if err != nil {
+		return err
+	}
+
+	packagePath := path.Join(pm.InstallPath, pkg.Name)
+
+	d = append([]byte("#!/usr/bin/env whalebrew\n"), d...)
+	return ioutil.WriteFile(packagePath, d, 0755)
+}
+
 // List lists installed packages
 func (pm *PackageManager) List() (map[string]*Package, error) {
 	packages := make(map[string]*Package)

--- a/script/build
+++ b/script/build
@@ -1,22 +1,10 @@
 #!/bin/bash
 
-make_build_dir() {
-  mkdir -p build && cd build
-}
+set -e
 
-build_project() {
-  gox -osarch="linux/amd64" -osarch="darwin/amd64" ../
-}
+mkdir -p build
+cd build
+gox -osarch="linux/amd64" -osarch="darwin/amd64" ../
 
-rename_binaries() {
-  mv whalebrew_linux_amd64 whalebrew-Linux-x86_64 && \
-    mv whalebrew_darwin_amd64 whalebrew-Darwin-x86_64
-}
-
-main() {
-  make_build_dir \
-  && build_project \
-  && rename_binaries
-}
-
-main "$@"
+mv whalebrew_linux_amd64 whalebrew-Linux-x86_64
+mv whalebrew_darwin_amd64 whalebrew-Darwin-x86_64

--- a/script/build
+++ b/script/build
@@ -1,7 +1,22 @@
 #!/bin/bash
-mkdir -p build
-cd build
-gox -osarch="linux/amd64" -osarch="darwin/amd64" ../
 
-mv whalebrew_linux_amd64 whalebrew-Linux-x86_64
-mv whalebrew_darwin_amd64 whalebrew-Darwin-x86_64
+make_build_dir() {
+  mkdir -p build && cd build
+}
+
+build_project() {
+  gox -osarch="linux/amd64" -osarch="darwin/amd64" ../
+}
+
+rename_binaries() {
+  mv whalebrew_linux_amd64 whalebrew-Linux-x86_64 && \
+    mv whalebrew_darwin_amd64 whalebrew-Darwin-x86_64
+}
+
+main() {
+  make_build_dir \
+  && build_project \
+  && rename_binaries
+}
+
+main "$@"


### PR DESCRIPTION
While developing a package I was switching between a local docker image and production image, which meant I was repeatedly uninstalling (which prompts for input) and installing. I added force install flag to support installing regardless whether the package is installed or not.