### PR TITLE
Use customizable working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ There are some labels you can use to configure how Whalebrew installs your image
 
         LABEL io.whalebrew.config.networks '["host"]'
 
+* `io.whalebrew.config.working_dir`: The path the working directory should be bound to in the container. For example putting this in your image's `Dockerfile` will ensure the working directory is available in /working_directory in the container
+
+        LABEL io.whalebrew.config.working_dir '/working_directory'
+
+#### Using user environment variables
+
+All three io.whalebrew.config.working_dir, io.whalebrew.config.volumes and io.whalebrew.config.environment are expanded with user environment variables at the time the container is launched. For example Adding the following line in your image's `Dockerfile` will:
+
+- bind your working directory to the container, keeping the same path
+- ensure the working directory of the container is the same as the user's one
+
+        LABEL io.whalebrew.config.working_dir '$PWD'
+
 ### Whalebrew images
 
 We maintain a set of packages which are known to follow these requirements under the `whalebrew` organization on [GitHub](https://github.com/whalebrew) and [Docker Hub](https://hub.docker.com/u/whalebrew/). If you want to add a package to this, open a pull request against [whalebrew-packages](https://github.com/whalebrew/whalebrew-packages).

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -60,11 +60,11 @@ var runCommand = &cobra.Command{
 				volume = user.HomeDir + volume[1:]
 			}
 			dockerArgs = append(dockerArgs, "-v")
-			dockerArgs = append(dockerArgs, volume)
+			dockerArgs = append(dockerArgs, os.ExpandEnv(volume))
 		}
 		for _, envvar := range pkg.Environment {
 			dockerArgs = append(dockerArgs, "-e")
-			dockerArgs = append(dockerArgs, envvar)
+			dockerArgs = append(dockerArgs, os.ExpandEnv(envvar))
 		}
 		for _, portmap := range pkg.Ports {
 			dockerArgs = append(dockerArgs, "-p")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -44,8 +44,8 @@ var runCommand = &cobra.Command{
 			"run",
 			"--interactive",
 			"--rm",
-			"--workdir", "/workdir",
-			"-v", fmt.Sprintf("%s:/workdir", cwd),
+			"--workdir", os.ExpandEnv(pkg.WorkingDir),
+			"-v", fmt.Sprintf("%s:%s", cwd, os.ExpandEnv(pkg.WorkingDir)),
 		}
 		if terminal.IsTerminal(int(os.Stdin.Fd())) {
 			dockerArgs = append(dockerArgs, "--tty")
@@ -80,8 +80,8 @@ var runCommand = &cobra.Command{
 			return err
 		}
 		dockerArgs = append(dockerArgs, "-u")
-		dockerArgs = append(dockerArgs, user.Uid + ":" + user.Gid)
-		
+		dockerArgs = append(dockerArgs, user.Uid+":"+user.Gid)
+
 		dockerArgs = append(dockerArgs, pkg.Image)
 		dockerArgs = append(dockerArgs, args[1:]...)
 


### PR DESCRIPTION
I like the idea of being able to run a command with a working directory matching the host current directory (thinking of copy pasting error messages for debug)

This PR adds this feature as well as providing a convenient way to derive environment variables and volumes from user's environment

